### PR TITLE
Adjust test so that it fails for the right reasons.

### DIFF
--- a/tests/acceptance/00_basics/ifelapsed/redmine_6334/main.cf
+++ b/tests/acceptance/00_basics/ifelapsed/redmine_6334/main.cf
@@ -37,7 +37,7 @@ bundle agent check
                               };
 
   classes:
-      "pass_$(pass_strings)_$(activations)" expression => regcmp(".*Called from $(pass_strings).*",
+      "pass_$(pass_strings)_$(activations)" expression => regcmp(".*R: Called from $(pass_strings).*",
                                                                  "$($(activations))");
 
       "ok" and => { @(pass_classes) },

--- a/tests/acceptance/00_basics/ifelapsed/redmine_6334/main.cf.sub
+++ b/tests/acceptance/00_basics/ifelapsed/redmine_6334/main.cf.sub
@@ -2,7 +2,7 @@ bundle agent example
 {
 
   methods:
-    "test" usebundle => test;
+    "test" usebundle => test, action => now;
 
 }
 
@@ -27,8 +27,13 @@ bundle agent call_report_now
 }
 bundle agent report_now(caller)
 {
+  vars:
+    first::
+       "count" string => "first";
+    second::
+       "count" string => "second";
   reports:
-    "Called from $(caller)"
+    "Called from $(caller) ($(count))"
       action => now;
 }
 


### PR DESCRIPTION
Test passes if second cf-agent invokation also uses -K, which
is expected (and a crude workaround). But at least it shows that
the test is implemented correctly now.

The regex can probably be made less aggressive, but it does the job.
